### PR TITLE
add python-decouple example

### DIFF
--- a/clients/settings.py
+++ b/clients/settings.py
@@ -11,6 +11,7 @@ https://docs.djangoproject.com/en/2.0/ref/settings/
 """
 
 import os
+from decouple import config
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -24,15 +25,18 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 #with open('/opt/secret.txt') as secret:
 #    SECRET_KEY = secret.read().strip()
 
-SECRET_KEY="li1b(&geuh#a1q5(hvk09_47#$t1%arni-$sh-$ra=!hz(fsw7"
+SECRET_KEY = config('SECRET_KEY')
 
 # SECURITY WARNING: don't run with debug turned on in production!
+APP_ENVIRONMENT = config('APP_ENVIRONMENT', 'prod')
+
 DEBUG = True
 
+if APP_ENVIRONMENT == 'prod':
+    DEBUG = False
+
+
 ALLOWED_HOSTS = ['192.168.42.17','192.168.24.2','127.0.0.1']
-
-
-
 
 # Application definition
 

--- a/env.template
+++ b/env.template
@@ -1,0 +1,2 @@
+SECRET_KEY=keep-this-secret
+APP_ENVIRONMENT=dev or prod

--- a/requeriments.txt
+++ b/requeriments.txt
@@ -2,3 +2,4 @@ Django==2.0.6
 Pillow==5.1.0
 pytz==2018.4
 WeasyPrint==46
+python-decouple


### PR DESCRIPTION
Example of how to use [python-decouple](https://pypi.org/project/python-decouple/) to store configuration details in the environment as indecated by https://12factor.net/config.

To run the project with this change a file named .env must be created and populated. An example is provided in the file env.template. The varibles can also be exported to the environment.